### PR TITLE
Replace event.keyCode with event.key.

### DIFF
--- a/index.js
+++ b/index.js
@@ -504,13 +504,12 @@ function setEventListeners(){
 
     document.addEventListener("keydown", function(event) {
 
-        var key = event.keyCode; // ASCII
         if (!pause && !gameover){
 
-            switch (key) {
+            switch (event.key) {
                 //left
-                case 37 : //left arrow
-                case 65 : // A
+                case "ArrowLeft" : //left arrow
+                case "a" : case "A" : // A
                     if(tplayer < -0.85){
                         break;
                     }
@@ -518,8 +517,8 @@ function setEventListeners(){
                     break;
 
                 //right
-                case 39 : //right arrow
-                case 68 : // D
+                case "ArrowRight" : //right arrow
+                case "d" : case "D" : // D
                     if(tplayer > 0.85){
                         break;
                     }
@@ -533,13 +532,11 @@ function setEventListeners(){
 
     document.addEventListener("keypress", function(event) {
 
-        var key = event.keyCode; // ASCII
-
-        switch (key) {
+        switch (event.key) {
 
             //shoot or restart
-            case 32 : // space bar
-            case 119 : // w
+            case " " : // space bar
+            case "w" : case "W": // w
                 if (!pause && !gameover && bulletready) { // shoot
                     tybullet = -0.75;
                     txbullet = tplayer;
@@ -549,7 +546,7 @@ function setEventListeners(){
                 }
 
                 break;
-            case 114: // R
+            case "r": case "R": // R
                 if (gameover) { // restart game
 
                     resetlevel();
@@ -569,7 +566,7 @@ function setEventListeners(){
                 break;
 
             //pause
-            case 112 : // P
+            case "p" : case "P": // P
                 if (!gameover) {
                     pause = !pause;
                     if(pause){


### PR DESCRIPTION
Fixes #2. The problem was that `event.keyCode` always had the value `0` for
`keypress` events in Mozilla Firefox, whereas `event.charCode` would have
worked. This commit replaces usage of the deprecated `event.keyCode` with
the newer, more non-implementation-dependent `event.key`.